### PR TITLE
Fix: assertRedirect() does not check URI

### DIFF
--- a/src/CI3Compatible/Test/TestRequest.php
+++ b/src/CI3Compatible/Test/TestRequest.php
@@ -124,9 +124,7 @@ class TestRequest
      */
     public function assertRedirect(string $uri, ?int $code = null): void
     {
-        // @TODO check URI
-        $uri;
-        $this->result->assertRedirect();
+        $this->result->assertRedirectTo($uri);
 
         if ($code === null) {
             return;


### PR DESCRIPTION
**Description**
- add to check URI in `$this->assertRedirect()`

**Checklist:**
- [ ] Component(s) with PHPDocs
- [x] Unit testing, with >85% coverage
- [ ] Document updated
- [x] Conforms to coding standard
